### PR TITLE
Major changes in Song/Artist relationships and some minor fixes

### DIFF
--- a/RMD.Business/Services/SongService.cs
+++ b/RMD.Business/Services/SongService.cs
@@ -49,11 +49,17 @@ namespace RMD.Business.Services
 					return Result<Song>.Failure($"A song with the name {newSongDto.Title} already exists in the database.");
 				}
 
+
+				var artist = await _context.Artists.FindAsync(newSongDto.ArtistId);
+				if(artist == null)
+				{
+					return Result<Song>.Failure("Artist not found.");
+				}
+
 				var newSong = new Song
 				{
 					Title = newSongDto.Title,
 					RemixArtist = newSongDto.RemixArtist,
-					Artist = newSongDto.Artist,
 					Length = newSongDto.Length,
 					Genre = newSongDto.Genre,
 					ExtendedMix = newSongDto.ExtendedMix,
@@ -63,7 +69,11 @@ namespace RMD.Business.Services
 					Stored = newSongDto.Stored,
 					Wanted = newSongDto.Wanted,
 					WantedSongUrl = newSongDto.WantedSongUrl,
-					Favorite = newSongDto.Favorite
+					Favorite = newSongDto.Favorite,
+
+					ArtistId = newSongDto.ArtistId.Value,
+					Artist = artist,
+
 				};
 
 				await _context.Songs.AddAsync(newSong);
@@ -205,7 +215,7 @@ namespace RMD.Business.Services
 
 				song.Title = updatedSongDto.Title;
 				song.RemixArtist = updatedSongDto.RemixArtist;
-				song.Artist = updatedSongDto.Artist;
+				song.ArtistId = updatedSongDto.ArtistId.Value;
 				song.Length = updatedSongDto.Length;
 				song.Genre = updatedSongDto.Genre;
 				song.ExtendedMix = updatedSongDto.ExtendedMix;
@@ -214,6 +224,7 @@ namespace RMD.Business.Services
 				song.PlayedInEp = updatedSongDto.PlayedInEp;
 				song.Stored = updatedSongDto.Stored;
 				song.Wanted = updatedSongDto.Wanted;
+				song.WantedSongUrl = updatedSongDto.WantedSongUrl;
 
 				_context.Songs.Update(song);
 				await _context.SaveChangesAsync();

--- a/RMD.Data/Context/RMDContext.cs
+++ b/RMD.Data/Context/RMDContext.cs
@@ -24,7 +24,7 @@ namespace RMD.Data.Context
 					SongId=1, 
 					Title="Hands Up Track (Test Remix)", 
 					RemixArtist="Test",
-					Artist="Artist",
+					ArtistId=1,
 					Length="02:23",
 					Genre="Hands Up",
 					ExtendedMix=true,

--- a/RMD.Data/Migrations/20250428005939_InitialCreate.Designer.cs
+++ b/RMD.Data/Migrations/20250428005939_InitialCreate.Designer.cs
@@ -11,7 +11,7 @@ using RMD.Data.Context;
 namespace RMD.Data.Migrations
 {
     [DbContext(typeof(RMDContext))]
-    [Migration("20250310214026_InitialCreate")]
+    [Migration("20250428005939_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -87,9 +87,8 @@ namespace RMD.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("SongId"));
 
-                    b.Property<string>("Artist")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                    b.Property<int>("ArtistId")
+                        .HasColumnType("int");
 
                     b.Property<bool>("ExtendedMix")
                         .HasColumnType("bit");
@@ -133,13 +132,15 @@ namespace RMD.Data.Migrations
 
                     b.HasKey("SongId");
 
+                    b.HasIndex("ArtistId");
+
                     b.ToTable("Songs");
 
                     b.HasData(
                         new
                         {
                             SongId = 1,
-                            Artist = "Artist",
+                            ArtistId = 1,
                             ExtendedMix = true,
                             Favorite = true,
                             Genre = "Hands Up",
@@ -153,6 +154,22 @@ namespace RMD.Data.Migrations
                             Wanted = false,
                             WantedSongUrl = "https://www.soundcloud.com/RejackHS"
                         });
+                });
+
+            modelBuilder.Entity("RMD.Data.Models.Song", b =>
+                {
+                    b.HasOne("RMD.Data.Models.Artist", "Artist")
+                        .WithMany("Songs")
+                        .HasForeignKey("ArtistId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Artist");
+                });
+
+            modelBuilder.Entity("RMD.Data.Models.Artist", b =>
+                {
+                    b.Navigation("Songs");
                 });
 #pragma warning restore 612, 618
         }

--- a/RMD.Data/Migrations/20250428005939_InitialCreate.cs
+++ b/RMD.Data/Migrations/20250428005939_InitialCreate.cs
@@ -38,7 +38,6 @@ namespace RMD.Data.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Title = table.Column<string>(type: "nvarchar(150)", maxLength: 150, nullable: false),
                     RemixArtist = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    Artist = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Length = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Genre = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     ExtendedMix = table.Column<bool>(type: "bit", nullable: false),
@@ -48,11 +47,18 @@ namespace RMD.Data.Migrations
                     Stored = table.Column<bool>(type: "bit", nullable: false),
                     Wanted = table.Column<bool>(type: "bit", nullable: false),
                     WantedSongUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    Favorite = table.Column<bool>(type: "bit", nullable: false)
+                    Favorite = table.Column<bool>(type: "bit", nullable: false),
+                    ArtistId = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_Songs", x => x.SongId);
+                    table.ForeignKey(
+                        name: "FK_Songs_Artists_ArtistId",
+                        column: x => x.ArtistId,
+                        principalTable: "Artists",
+                        principalColumn: "ArtistId",
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.InsertData(
@@ -66,18 +72,23 @@ namespace RMD.Data.Migrations
 
             migrationBuilder.InsertData(
                 table: "Songs",
-                columns: new[] { "SongId", "Artist", "ExtendedMix", "Favorite", "Genre", "Length", "Played", "PlayedInEp", "RadioMix", "RemixArtist", "Stored", "Title", "Wanted", "WantedSongUrl" },
-                values: new object[] { 1, "Artist", true, true, "Hands Up", "02:23", true, 18, false, "Test", true, "Hands Up Track (Test Remix)", false, "https://www.soundcloud.com/RejackHS" });
+                columns: new[] { "SongId", "ArtistId", "ExtendedMix", "Favorite", "Genre", "Length", "Played", "PlayedInEp", "RadioMix", "RemixArtist", "Stored", "Title", "Wanted", "WantedSongUrl" },
+                values: new object[] { 1, 1, true, true, "Hands Up", "02:23", true, 18, false, "Test", true, "Hands Up Track (Test Remix)", false, "https://www.soundcloud.com/RejackHS" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Songs_ArtistId",
+                table: "Songs",
+                column: "ArtistId");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "Artists");
+                name: "Songs");
 
             migrationBuilder.DropTable(
-                name: "Songs");
+                name: "Artists");
         }
     }
 }

--- a/RMD.Data/Migrations/RMDContextModelSnapshot.cs
+++ b/RMD.Data/Migrations/RMDContextModelSnapshot.cs
@@ -84,9 +84,8 @@ namespace RMD.Data.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("SongId"));
 
-                    b.Property<string>("Artist")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                    b.Property<int>("ArtistId")
+                        .HasColumnType("int");
 
                     b.Property<bool>("ExtendedMix")
                         .HasColumnType("bit");
@@ -130,13 +129,15 @@ namespace RMD.Data.Migrations
 
                     b.HasKey("SongId");
 
+                    b.HasIndex("ArtistId");
+
                     b.ToTable("Songs");
 
                     b.HasData(
                         new
                         {
                             SongId = 1,
-                            Artist = "Artist",
+                            ArtistId = 1,
                             ExtendedMix = true,
                             Favorite = true,
                             Genre = "Hands Up",
@@ -150,6 +151,22 @@ namespace RMD.Data.Migrations
                             Wanted = false,
                             WantedSongUrl = "https://www.soundcloud.com/RejackHS"
                         });
+                });
+
+            modelBuilder.Entity("RMD.Data.Models.Song", b =>
+                {
+                    b.HasOne("RMD.Data.Models.Artist", "Artist")
+                        .WithMany("Songs")
+                        .HasForeignKey("ArtistId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Artist");
+                });
+
+            modelBuilder.Entity("RMD.Data.Models.Artist", b =>
+                {
+                    b.Navigation("Songs");
                 });
 #pragma warning restore 612, 618
         }

--- a/RMD.Data/Models/Artist.cs
+++ b/RMD.Data/Models/Artist.cs
@@ -17,6 +17,8 @@ namespace RMD.Data.Models
         public string? ProfilePicUrl { get; set; }
         public string? DiscogsUrl { get; set; }
 
+        public ICollection<Song> Songs { get; set; } = new List<Song>();
+
         public Artist()
         {
             Nationality = String.Empty;

--- a/RMD.Data/Models/DTO/ArtistDto.cs
+++ b/RMD.Data/Models/DTO/ArtistDto.cs
@@ -21,5 +21,7 @@ namespace RMD.Data.Models.DTO
 
 
 		public string? DiscogsUrl { get; set; }
+
+		public int ArtistId { get; set; }
 	}
 }

--- a/RMD.Data/Models/DTO/SongDto.cs
+++ b/RMD.Data/Models/DTO/SongDto.cs
@@ -10,8 +10,8 @@ namespace RMD.Data.Models.DTO
 
 		public string? RemixArtist { get; set; }
 
-		[Required(ErrorMessage = "An artist is required.")]
-		public required string Artist { get; set; }
+		//[Required(ErrorMessage = "An artist is required.")]
+		//public required string Artist { get; set; }
 
 		[Required(ErrorMessage = "Song length is required.")]
 		public required string Length { get; set; }
@@ -28,5 +28,9 @@ namespace RMD.Data.Models.DTO
 		public bool Wanted { get; set; }
 		public string? WantedSongUrl { get; set; }
 		public bool Favorite { get; set; }
+
+
+		[Required(ErrorMessage = "Artist must be selected.")]
+		public int? ArtistId { get; set; }
 	}
 }

--- a/RMD.Data/Models/Song.cs
+++ b/RMD.Data/Models/Song.cs
@@ -14,9 +14,9 @@ namespace RMD.Data.Models
 
         public string? RemixArtist { get; set; }
 
-		[Required]
-        public required string Artist { get; set; }
-		//public ICollection<Artist> Artist { get; set; } = new List<Artist>();
+		//[Required]
+  //      public required string Artist { get; set; }
+		
 		[Required]
         public required string Length { get; set; }
 
@@ -30,6 +30,11 @@ namespace RMD.Data.Models
         public bool Wanted { get; set; }
         public string? WantedSongUrl { get; set; }
         public bool Favorite { get; set; }
+
+		public int ArtistId { get; set; }
+
+        [Required]
+        public Artist Artist { get; set; } = null!;
 
 		public Song()
         {

--- a/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
+++ b/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
@@ -1,5 +1,9 @@
 ﻿@page "/Modal5"
 @using RMD.Data.Models
+@using RMD.Data.Models.DTO
+@using RMD.Business.Services
+
+@inject IArtistService ArtistService
 
 <div class="modal-backdrop">
     <div class="container_parent">
@@ -18,22 +22,32 @@
 
                     <div id="form-group">
                         <label>Remixartist</label>
-                        <select name="remixartist" id="remixartist" class="form-control" @bind="editableSong.RemixArtist">
-                            <option value="rob_mayth">Rob Mayth</option>
-                            <option value="lazerzf!ne">Lazerzf!ne</option>
-                            <option value="tube_tonic_&_dj_shandar">Tube Tonic & DJ Shandar</option>
-                            <option value="masterblaster">Master Blaster</option>
-                        </select>
+
+                        <InputSelect @bind-Value="editableSong.RemixArtist" class="form-control" style="width: 18rem;">
+                            <option value="">Velg remixartist</option>
+
+                            @foreach (var artist in allArtists)
+                            {
+                                <option value="@artist.Name">@artist.Name</option>
+                            }
+
+                        </InputSelect>
+                        
                     </div>
 
-                    <div class="form-group" style="margin-bottom: 15px;">
-                        <label for="artist">Artist</label>
-                        <select name="artist" id="artist" class="form-control" @bind="editableSong.Artist">
-                            <option value="rob_mayth">Rob Mayth</option>
-                            <option value="lazerzf!ne">Lazerzf!ne</option>
-                            <option value="tube_tonixc_&_dj_shandar">Tube Tonic & DJ Shandar</option>
-                            <option value="masterblaster">Master Blaster</option>
-                        </select>
+                    <div id="form-group" style="margin-bottom: 15px;">
+                        <label>Artist</label>
+                        
+                        <InputSelect @bind-Value="editableSong.ArtistId" class="form-control" style="width: 18rem;">
+                            <option value="">Velg artist</option>
+
+                            @foreach (var artist in allArtists)
+                            {
+                                <option value="@artist.ArtistId">@artist.Name</option>
+                            }
+
+                        </InputSelect>
+
                     </div>
 
                     <div id="form-group">
@@ -44,10 +58,13 @@
                     <div id="form-group">
                         <label>Sjanger</label>
                         <select name="sjanger" id="sjanger" class="form-control" @bind="editableSong.Genre">
-                            <option value="hands_up">Hands Up</option>
-                            <option value="hard_trance">Hard Trance</option>
-                            <option value="hardstyle">Hardstyle</option>
-                            <option value="trance">Trance</option>
+                            <option value="Hands Up">Hands Up</option>
+                            <option value="Hard Trance">Hard Trance</option>
+                            <option value="Hardstyle">Hardstyle</option>
+                            <option value="Jumpstyle">Jumpstyle</option>
+                            <option value="Trance">Trance</option>
+                            <option value="Happy Hardcore">Happy Hardcore</option>
+                            <option value="UK Hardcore">UK Hardcore</option>
                         </select>
                     </div>
                 </div>
@@ -67,24 +84,24 @@
                     </div>
 
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault" @bind="playedIsToggled">
+                        <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault" @bind="editableSong.Played">
                         <label class="form-check-label" for="flexSwitchCheckDefault">Spilt</label>
                         <label class="col-form-label-sm">Låten er spilt i en tidligere mixtape.</label>
                     </div>
 
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault">
+                        <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault" @bind="editableSong.Stored">
                         <label class="form-check-label" for="flexSwitchCheckDefault">Lagret</label>
                         <label class="col-form-label-sm">Låten er lagret i samlingen.</label>
                     </div>
 
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault" @bind="wantedIsToggled">
+                        <input class="form-check-input" type="checkbox" id="flexSwitchCheckDefault" @bind="editableSong.Wanted">
                         <label class="form-check-label" for="flexSwitchCheckDefault">Ønsket</label>
                         <label class="col-form-label-sm">Låten er ønsket og må skaffes.</label>
                     </div>
 
-                    @if (playedIsToggled)
+                    @if (editableSong.Played)
                     {
                         <div class="toggledInput">
                             <div id="form-group">
@@ -95,7 +112,7 @@
                         </div>
                     }
 
-                    @if (wantedIsToggled)
+                    @if (editableSong.Wanted)
                     {
                         <div class="toggledInput">
                             <div id="form-group">
@@ -110,7 +127,7 @@
             </div>
 
             <div class="button_container">
-                
+
                 <div class="cancel_button">
                     <button type="button" class="btn btn-secondary" @onclick="CloseEditModal">
                         Avbryt
@@ -133,9 +150,6 @@
 
 @code {
 
-    private bool playedIsToggled = false;
-    private bool wantedIsToggled = false;
-
     [Parameter] public bool IsVisible { get; set; }
 
     [Parameter] public EventCallback<bool> OnClose { get; set; }
@@ -143,15 +157,37 @@
 
     [Parameter] public Song? Song { get; set; }
 
+    private List<Artist> allArtists = new();
+
     // Init to string.empty because required
     private Song editableSong = new()
     {
         Title = string.Empty,
+        RemixArtist = null,
         Length = string.Empty,
         Genre = string.Empty,
-        Artist = string.Empty
+        ArtistId = 0,
+
+        SongId = 0,
+        Stored = false,
+        Wanted = false, 
+        Played = false,
+        ExtendedMix = false,
+        Favorite = false,
+        WantedSongUrl = string.Empty,
+       
+
     };
 
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await ArtistService.GetAllArtistsAsync();
+
+        if (result.IsSuccess)
+        {
+            allArtists = result.Value.ToList();
+        }
+    }
 
     private async Task SaveChangesAsync()
     {
@@ -175,6 +211,7 @@
                     SongId = Song.SongId,
                     Title = Song.Title,
                     Artist = Song.Artist,
+                    ArtistId = Song.ArtistId,
                     RemixArtist = Song.RemixArtist,
                     Length = Song.Length,
                     Genre = Song.Genre,

--- a/RMD.GUI/Pages/Components/Modals/EditSongModal.razor.css
+++ b/RMD.GUI/Pages/Components/Modals/EditSongModal.razor.css
@@ -157,9 +157,8 @@ input, select {
         display: flex;
         flex-direction: column;
         justify-content: center;
-       /* max-width: 100%;
+        /* max-width: 100%;
         height: auto;*/
-
     }
 
     .bi-pencil-square {
@@ -170,7 +169,7 @@ input, select {
         max-width: 100%;
         height: auto;
     }
-    
+
     .main_form_container {
         z-index: 1050;
         margin-top: 3rem;
@@ -207,16 +206,23 @@ input, select {
         /*width: 40rem;*/
         max-width: 100%;
         height: auto;
-        
     }
 
-    input{
+    input {
         width: 18rem;
         /*max-width: 100%;
         height: auto;*/
     }
 
-    select{
+    select {
+        width: 18rem;
+    }
+
+    .select-wrapper {
+        width: 18rem;
+    }
+
+    .input-select-wrapper {
         width: 18rem;
     }
 
@@ -266,13 +272,11 @@ input, select {
 
 
     .button_container {
-       /* display: flex;
+        /* display: flex;
         flex-direction: column;
         align-items: center;*/
-       display: flex; 
-       flex-direction: column;
-      
- 
+        display: flex;
+        flex-direction: column;
     }
 
     .btn {
@@ -291,15 +295,14 @@ input, select {
 
     /*.cancel_button {
         margin-top: 2rem;*/
-       /* margin-right: 2rem;*/
-       /* position: relative;*/
-        /*display: inline-block;*/
+    /* margin-right: 2rem;*/
+    /* position: relative;*/
+    /*display: inline-block;*/
     /*}*/
 
     .save_button {
         margin-top: 2rem;
         margin-left: 0rem;
         margin-bottom: 2rem;
-
     }
 }

--- a/RMD.GUI/Pages/RegisterArtist.razor
+++ b/RMD.GUI/Pages/RegisterArtist.razor
@@ -15,7 +15,7 @@
 <div class="container_parent">
 	<div class="main_form_container">
 
-		
+
 
 		<h3>Registrer artist</h3>
 
@@ -29,57 +29,57 @@
 				</div>
 
 				<div class="info_child">
-					<label for="artistNationality">Byttes ut med komponent </label>
+					<label for="artistNationality">Land </label>
 					<InputSelect @bind-Value="newArtistDto.Nationality" class="form-control">
 						<option value="" disabled selected>Nasjonalitet</option>
 						<option value="Ukjent Opphav" class="fw-bold"> Ukjent nasjonalitet</option>
-						<option value="Norway" class="fw-bold"> 🇳🇴 Norge</option>
-						<option value="Sweden" class="fw-bold"> 🇸🇪 Sverige</option>
-						<option value="Denmark" class="fw-bold"> 🇩🇰 Danmark</option>
-						<option value="Finland" class="fw-bold"> 🇫🇮 Finland</option>
-						<option value="Germany" class="fw-bold"> 🇩🇪 Tyskland</option>
-						<option value="Iceland" class="fw-bold"> 🇮🇸 Island</option>
-						<option value="Australia" class="fw-bold"> 🇦🇺 Australia</option>
-						<option value="United States" class="fw-bold"> 🇺🇸 USA</option>
-						<option value="Netherlands" class="fw-bold"> 🇳🇱 Nederland</option>
-						<option value="United Kingdom" class="fw-bold"> 🇬🇧 Storbritannia</option>
-						<option value="Turkey"> 🇹🇷 Tyrkia</option>
-						<option value="Thailand"> 🇹🇭 Thailand</option>
-						<option value="Taiwan"> 🇹🇼 Taiwan</option>
-						<option value="Switzerland"> 🇨🇭 Sveits</option>
-						<option value="Spain"> 🇪🇸 Spania</option>
-						<option value="South Africa"> 🇿🇦 Sør-Afrika</option>
-						<option value="Slovenia"> 🇸🇮 Slovenia</option>
-						<option value="Slovakia"> 🇸🇰 Slovakia</option>
-						<option value="Russian Federation"> 🇷🇺 Russland</option>
-						<option value="Romania"> 🇷🇴 Romania</option>
-						<option value="Portugal"> 🇵🇹 Portugal</option>
-						<option value="Poland"> 🇵🇱 Polen</option>
-						<option value="Peru"> 🇵🇪 Peru</option>
-						<option value="New Zealand"> 🇳🇿 New Zealand</option>
-						<option value="Mexico"> 🇲🇽 Mexico</option>
-						<option value="Lithuania"> 🇱🇹 Litauen</option>
-						<option value="Liechtenstein"> 🇱🇮 Liechtenstein</option>
-						<option value="Latvia"> 🇱🇻 Latvia</option>
-						<option value="Korea, Republic of"> 🇰🇷 Sør-Korea</option>
-						<option value="Japan"> 🇯🇵 Japan</option>
+						<option value="🇳🇴 Norge" class="fw-bold"> 🇳🇴 Norge</option>
+						<option value="🇸🇪 Sverige" class="fw-bold"> 🇸🇪 Sverige</option>
+						<option value="🇩🇰 Danmark" class="fw-bold"> 🇩🇰 Danmark</option>
+						<option value="🇫🇮 Finland" class="fw-bold"> 🇫🇮 Finland</option>
+						<option value="🇩🇪 Tyskland" class="fw-bold"> 🇩🇪 Tyskland</option>
+						<option value="🇮🇸 Island" class="fw-bold"> 🇮🇸 Island</option>
+						<option value="🇦🇺 Australia" class="fw-bold"> 🇦🇺 Australia</option>
+						<option value="🇺🇸 USA" class="fw-bold"> 🇺🇸 USA</option>
+						<option value="🇳🇱 Nederland" class="fw-bold"> 🇳🇱 Nederland</option>
+						<option value="🇬🇧 Storbritannia" class="fw-bold"> 🇬🇧 Storbritannia</option>
+						<option value="🇹🇷 Tyrkia"> 🇹🇷 Tyrkia</option>
+						<option value="🇹🇭 Thailand"> 🇹🇭 Thailand</option>
+						<option value="🇹🇼 Taiwan"> 🇹🇼 Taiwan</option>
+						<option value="🇨🇭 Sveits"> 🇨🇭 Sveits</option>
+						<option value="🇪🇸 Spania"> 🇪🇸 Spania</option>
+						<option value="🇿🇦 Sør-Afrika"> 🇿🇦 Sør-Afrika</option>
+						<option value="🇸🇮 Slovenia"> 🇸🇮 Slovenia</option>
+						<option value="🇸🇰 Slovakia"> 🇸🇰 Slovakia</option>
+						<option value="🇷🇺 Russland"> 🇷🇺 Russland</option>
+						<option value="🇷🇴 Romania"> 🇷🇴 Romania</option>
+						<option value="🇵🇹 Portugal"> 🇵🇹 Portugal</option>
+						<option value="🇵🇱 Polen"> 🇵🇱 Polen</option>
+						<option value="🇵🇪 Peru"> 🇵🇪 Peru</option>
+						<option value="🇳🇿 New Zealand"> 🇳🇿 New Zealand</option>
+						<option value="🇲🇽 Mexico"> 🇲🇽 Mexico</option>
+						<option value="🇱🇹 Litauen"> 🇱🇹 Litauen</option>
+						<option value="🇱🇮 Liechtenstein"> 🇱🇮 Liechtenstein</option>
+						<option value="🇱🇻 Latvia"> 🇱🇻 Latvia</option>
+						<option value="🇰🇷 Sør-Korea"> 🇰🇷 Sør-Korea</option>
+						<option value="🇯🇵 Japan"> 🇯🇵 Japan</option>
 						<option value="Italy"> 🇮🇹 Italia</option>
-						<option value="Israel"> 🇮🇱 Israel</option>
-						<option value="Ireland"> 🇮🇪 Irland</option>
-						<option value="Hungary"> 🇭🇺 Ungarn</option>
-						<option value="Greenland"> 🇬🇱 Grønland</option>
-						<option value="Greece"> 🇬🇷 Hellas</option>
-						<option value="Georgia"> 🇬🇪 Georgia</option>
-						<option value="France"> 🇫🇷 Frankrike</option>
-						<option value="Estonia"> 🇪🇪 Estland</option>
-						<option value="Czech Republic"> 🇨🇿 Tsjekkia</option>
-						<option value="Croatia"> 🇭🇷 Kroatia</option>
-						<option value="Canada"> 🇨🇦 Canada</option>
-						<option value="Belgium"> 🇧🇪 Belgia</option>
-						<option value="Belarus"> 🇧🇾 Hviterussland</option>
-						<option value="Austria"> 🇦🇹 Østerrike</option>
-						<option value="Argentina"> 🇦🇷 Argentina</option>
-						<option value="Ukraine"> 🇺🇦 Ukraina</option>
+						<option value="🇮🇹 Italia"> 🇮🇱 Israel</option>
+						<option value="🇮🇪 Irland"> 🇮🇪 Irland</option>
+						<option value="🇭🇺 Ungarn"> 🇭🇺 Ungarn</option>
+						<option value="🇬🇱 Grønland"> 🇬🇱 Grønland</option>
+						<option value="🇬🇷 Hellas"> 🇬🇷 Hellas</option>
+						<option value="🇬🇪 Georgia"> 🇬🇪 Georgia</option>
+						<option value="🇫🇷 Frankrike"> 🇫🇷 Frankrike</option>
+						<option value="🇪🇪 Estland"> 🇪🇪 Estland</option>
+						<option value="🇨🇿 Tsjekkia"> 🇨🇿 Tsjekkia</option>
+						<option value="🇭🇷 Kroatia"> 🇭🇷 Kroatia</option>
+						<option value="🇨🇦 Canada"> 🇨🇦 Canada</option>
+						<option value="🇧🇪 Belgia"> 🇧🇪 Belgia</option>
+						<option value="🇧🇾 Hviterussland"> 🇧🇾 Hviterussland</option>
+						<option value="🇦🇹 Østerrike"> 🇦🇹 Østerrike</option>
+						<option value="🇦🇷 Argentina"> 🇦🇷 Argentina</option>
+						<option value="🇺🇦 Ukraina"> 🇺🇦 Ukraina</option>
 					</InputSelect>
 				</div>
 			</div>
@@ -136,36 +136,36 @@
 
 	private async Task SaveArtist()
 	{
+		Console.WriteLine("SaveArtist called"); 
 
 		var result = await ArtistService.CreateNewArtistAsync(newArtistDto);
 
 		if (result.IsSuccess)
 		{
-			newArtistDto = new ArtistDto
-			{
-				Name = string.Empty,
-				Nationality = string.Empty,
-				FacebookUrl = "",
-				SoundcloudUrl = "",
-				ProfilePicUrl = "",
-				DiscogsUrl = ""
+			Console.WriteLine("Artist successfully created with ID: " + result.Value.ArtistId); 
 
-			};
+			newArtistDto = new ArtistDto
+				{
+					Name = string.Empty,
+					Nationality = string.Empty,
+					FacebookUrl = "",
+					SoundcloudUrl = "",
+					ProfilePicUrl = "",
+					DiscogsUrl = ""
+				};
 
 			warningModalDuplicateVisible = false;
+			StateHasChanged();
 		}
-
 		else
 		{
-			Console.WriteLine($"Error: {result.Error}");
+			Console.WriteLine($"Error creating artist: {result.Error}");
 
-			if(result.Error.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+			if (result.Error.Contains("already exists", StringComparison.OrdinalIgnoreCase))
 			{
 				warningModalDuplicateVisible = true;
 			}
 		}
-
-
 	}
 
 	private void CloseModal()

--- a/RMD.GUI/Pages/RegisterSong.razor
+++ b/RMD.GUI/Pages/RegisterSong.razor
@@ -5,6 +5,7 @@
 @using RMD.Business.Services
 @using RMD.GUI.Pages.Components.Modals
 @inject ISongService SongService 
+@inject IArtistService ArtistService
 @page "/AddSong"
 
 <PageTitle>RMD | Add a new song</PageTitle>
@@ -15,7 +16,7 @@
 <div class="container_parent">
     <div class="main_form_container">
 
-        
+
 
         <h3>Registrer låt</h3>
 
@@ -31,47 +32,29 @@
                     <div id="form-group">
                         <label>Remixartist</label>
                         <InputSelect @bind-Value="newSongDto.RemixArtist" class="form-control">
-                            <option value="">
+                            <option value="">Velg remixartist</option>
 
-                            </option>
+                            @foreach (var artist in allArtists)
+                            {
+                                <option value="@artist.Name">@artist.Name</option>
+                            }
 
-                            <option value="Rob Mayth">
-                                Rob Mayth
-                            </option>
-
-                            <option value="Lazerzf!ne">
-                                Lazerzf!ne
-                            </option>
-
-                            <option value="Tube Tonic & DJ Shandar">
-                                Tube Tonic & DJ Shandar
-                            </option>
-
-                            <option value="Master Blaster">
-                                Master Blaster
-                            </option>
                         </InputSelect>
+                        <ValidationMessage For="@(() => newSongDto.RemixArtist)" />
                     </div>
 
                     <div id="form-group" style="margin-bottom: 15px;">
                         <label>Artist</label>
-                        <InputSelect @bind-Value="newSongDto.Artist" class="form-control">
-                            <option value="Rob Mayth">
-                                Rob Mayth
-                            </option>
+                        <InputSelect @bind-Value="newSongDto.ArtistId" class="form-control">
+                            <option value="">Velg artist</option>
 
-                            <option value="Lazerzf!ne">
-                                Lazerzf!ne
-                            </option>
+                            @foreach (var artist in allArtists)
+                            {
+                                <option value="@artist.ArtistId">@artist.Name</option>
+                            }
 
-                            <option value="Tube Tonic & DJ Shandar">
-                                Tube Tonic & DJ Shandar
-                            </option>
-
-                            <option value="Master Blaster">
-                                Master Blaster
-                            </option>
                         </InputSelect>
+                        <ValidationMessage For="@(() => newSongDto.ArtistId)" />
                     </div>
 
 
@@ -83,21 +66,13 @@
                     <div id="form-group">
                         <label>Sjanger</label>
                         <InputSelect @bind-Value="newSongDto.Genre" class="form-control">
-                            <option value="Hands Up">
-                                Hands Up
-                            </option>
-
-                            <option value="Hard Trance">
-                                Hard Trance
-                            </option>
-
-                            <option value="Hardstyle">
-                                Hardstyle
-                            </option>
-
-                            <option value="Trance">
-                                Trance
-                            </option>
+                            <option value="Hands Up">Hands Up</option>
+                            <option value="Hard Trance">Hard Trance</option>
+                            <option value="Hardstyle">Hardstyle</option>
+                            <option value="Jumpstyle">Jumpstyle</option>
+                            <option value="Trance">Trance</option>
+                            <option value="Happy Hardcore">Happy Hardcore</option>
+                            <option value="UK Hardcore">UK Hardcore</option>
                         </InputSelect>
                     </div>
                 </div>
@@ -117,9 +92,9 @@
 
                     <div class="form-check form-switch">
                         <input class="form-check-input"
-                               type="checkbox"
-                               id="playedSwitch"
-                               @bind="playedIsToggled" />
+                        type="checkbox"
+                        id="playedSwitch"
+                        @bind="playedIsToggled" />
                         <label class="form-check-label" for="playedSwitch">Spilt</label>
                         <label class="col-form-label-sm">Låten er spilt i en tidligere mixtape.</label>
                     </div>
@@ -133,9 +108,9 @@
 
                     <div class="form-check form-switch">
                         <input class="form-check-input"
-                               type="checkbox"
-                               id="wantedSwitch"
-                               @bind="wantedIsToggled" />
+                        type="checkbox"
+                        id="wantedSwitch"
+                        @bind="wantedIsToggled" />
                         <label class="form-check-label" for="wantedSwitch">Ønsket</label>
                         <label class="col-form-label-sm">Låten er ønsket og må skaffes.</label>
                     </div>
@@ -172,12 +147,12 @@
             </div>
 
             <div class="validation-container-song">
-                  <ValidationSummary class="fade-in"/>
+                <ValidationSummary class="fade-in"/>
             </div>
         </EditForm>
     </div>
 
-    
+
 
 </div>
 
@@ -189,15 +164,27 @@
     private bool wantedIsToggled = false;
     private bool warningModalDuplicateVisible = false;
 
+    private List<Artist> allArtists = new();
+
     private SongDto newSongDto = new SongDto
     {
         //Init required members
         Title = String.Empty,
         RemixArtist = String.Empty,
-        Artist = String.Empty,
+        ArtistId = 0, 
         Length = String.Empty,
         Genre = String.Empty,
     };
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await ArtistService.GetAllArtistsAsync();
+
+        if (result.IsSuccess)
+        {
+            allArtists = result.Value.ToList();
+        }
+    }
 
     private void CloseModal()
     {
@@ -224,7 +211,7 @@
                 {
                     Title = String.Empty,
                     RemixArtist = String.Empty,
-                    Artist = String.Empty,
+                    ArtistId = null,
                     Length = String.Empty,
                     Genre = String.Empty,
                     ExtendedMix = false,

--- a/RMD.GUI/Pages/SongListPage.razor
+++ b/RMD.GUI/Pages/SongListPage.razor
@@ -159,7 +159,7 @@
 					style="max-width: 200px"
 					title="@song.Title"
 					>@song.Title</td>
-					<td>@song.Artist</td>
+					<td>@song.Artist?.Name</td>
 					<td>@song.RemixArtist</td>
 					<td>@song.Length</td>
 					<td>@song.Genre</td>
@@ -271,7 +271,7 @@
 
 			filtered = filtered.Where(song =>
 				(song.Title?.ToLower().Contains(lowerSearch) ?? false) ||
-				(song.Artist?.ToLower().Contains(lowerSearch) ?? false) ||
+				(song.Artist?.Name?.ToLower().Contains(lowerSearch) ?? false) ||
 				(song.RemixArtist?.ToLower().Contains(lowerSearch) ?? false)
 			);
 		}
@@ -314,7 +314,7 @@
 		var dto = new RMD.Data.Models.DTO.SongDto
 			{
 				Title = updatedSong.Title,
-				Artist = updatedSong.Artist,
+				ArtistId = updatedSong.ArtistId,
 				RemixArtist = updatedSong.RemixArtist,
 				Length = updatedSong.Length,
 				Genre = updatedSong.Genre,
@@ -324,6 +324,7 @@
 				PlayedInEp = updatedSong.PlayedInEp,
 				Stored = updatedSong.Stored,
 				Wanted = updatedSong.Wanted,
+				WantedSongUrl = updatedSong.WantedSongUrl
 			};
 
 		var result = await SongService.UpdateSongByIdAsync(updatedSong.SongId, dto);


### PR DESCRIPTION
 Major changes in Artist and Song relationship include: 

- [x] Song.cs : Replacing String Artist with Int ArtistId
- [x] Song.cs : Added navigation property Public Artist Artist
- [x] Artist.cs : Added navigation property Public List <Song> Songs
- [x] Updated DTOs, since user selects artist -> public int ArtistId
- [x] Ran migrations, updated database schema. 
- [x] Replaced hard coded data in drop downs with the new ArtistId prop, and displayed @artist.Name in list (for artist/remixer)
- [x] Updated the service - CreateNewSongAsync loads the artist entities based on ArtistId
- [x] Set both ArtistId and Artist nav props when creating new song

Minor fixes and corrections: 

- [x] Fixed issue where DTOs did not include WantedUrl
- [x] Fixed coutnry list so that flag emoji can be displayed on profile
- [x] Fixed the genre list's values and added more options
- [x] Fixed error in binding song checkboxes when editing a song