### PR TITLE
GUI Polishing

### DIFF
--- a/RMD.Business/Services/ToastService.cs
+++ b/RMD.Business/Services/ToastService.cs
@@ -4,7 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace RMD.Business.Services {
+namespace RMD.Business.Services
+{
 
 	/// <summary>
 	/// ToastService is a singleton service which is using an event (OnShow) to notify a the toast component when it's supposed to be displayed.
@@ -14,7 +15,7 @@ namespace RMD.Business.Services {
 
 	public class ToastService
 	{
-		public event Action<string, ToastType>? OnShow;	
+		public event Action<string, ToastType>? OnShow;
 		public void ShowToast(string message, ToastType type = ToastType.Info)
 		{
 			OnShow?.Invoke(message, type);

--- a/RMD.Data/Models/DTO/SongDto.cs
+++ b/RMD.Data/Models/DTO/SongDto.cs
@@ -19,6 +19,8 @@ namespace RMD.Data.Models.DTO
 		//public required string Artist { get; set; }
 
 		[Required(ErrorMessage = "Song length is required.")]
+		[RegularExpression(@"^[0-5]?\d:[0-5]\d$",
+		ErrorMessage = "Length input must match format: MM:SS")]
 		public required string Length { get; set; }
 
 		[Required(ErrorMessage = "Song genre is required.")]

--- a/RMD.Data/Models/DTO/SongUpdateDto.cs
+++ b/RMD.Data/Models/DTO/SongUpdateDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,6 +11,10 @@ namespace RMD.Data.Models.DTO
 	{
 		public int SongId { get; set; }
 		public string Title { get; set; } = string.Empty;
+
+		[Required]
+		[RegularExpression(@"^[0-5]?\d:[0-5]\d$",
+		ErrorMessage = "Length input must match format: MM:SS")]
 		public string Length { get; set; } = string.Empty;
 		public string Genre { get; set; } = string.Empty;
 		public bool ExtendedMix { get; set; }

--- a/RMD.GUI/Pages/ArtistListPage.razor.css
+++ b/RMD.GUI/Pages/ArtistListPage.razor.css
@@ -47,12 +47,11 @@
 }
 
 .grid_container {
-    max-height: 28rem;
+    max-height: 41rem;
     height: auto;
     overflow-y: auto;
-
     background-color: #00000050;
-    margin-top: 2rem;
+    margin-top: 0.8rem;
     padding: 2rem;
     border-radius: 20px;
     display: grid; /*
@@ -117,7 +116,7 @@ h3 {
     flex-direction: row;
     height: 2rem;
     margin-bottom: 2rem;*/
-
+    margin-top:-1rem;
     display: flex;
     flex-wrap: wrap;
     align-items: center;

--- a/RMD.GUI/Pages/ArtistProfile.razor
+++ b/RMD.GUI/Pages/ArtistProfile.razor
@@ -20,8 +20,7 @@
 	<WarningModalArtistDeletion IsVisible="deleteModalVisible" 
 	OnClose="ToggleDeleteModal"
 	Artist="artist"
-	OnDelete="OnArtistDeleted"
-	/>
+	OnDelete="OnArtistDeleted"/>
 }
 
 
@@ -93,8 +92,9 @@
 
 								}
 							</td>
-							<td>@(song.Favorite ? "⭐" : "❌")</td>
 							<td>@(song.Stored ? "✅" : "❌")</td>
+							<td>@(song.Favorite ? "⭐" : "❌")</td>
+							
 						</tr>
 
 					</tbody>

--- a/RMD.GUI/Pages/ArtistProfile.razor
+++ b/RMD.GUI/Pages/ArtistProfile.razor
@@ -135,7 +135,11 @@
 				<p><b>@artist?.Nationality</b></p>
 			</div>
 			<div class="text_control">
-				<p><b>🎵@artist?.Songs?.FirstOrDefault()?.Genre</b></p>
+				<p>
+					<b>
+						🎵 @artist?.SongArtists?.Where(sa => sa.Song != null).Select(sa => sa.Song).FirstOrDefault()?.Genre
+					</b>
+				</p>
 			</div>
 			<div class="text_control">
 				<a href="@artist?.FacebookUrl">

--- a/RMD.GUI/Pages/ArtistProfile.razor.css
+++ b/RMD.GUI/Pages/ArtistProfile.razor.css
@@ -65,7 +65,7 @@ a {
     text-decoration: none;
 }
     a:hover {
-        color: #aee1ff;
+        color: #43C000;
     }
 h3 {
     margin-top: 4.5rem;

--- a/RMD.GUI/Pages/Components/ArchiveTabParent.razor
+++ b/RMD.GUI/Pages/Components/ArchiveTabParent.razor
@@ -4,13 +4,13 @@
 	<ul class="nav nav-tabs">
 		<li class="nav-item">
 			<a class="nav-link @(selectedTab == 0 ? "active-tab" : "" )" @onclick="() => SelectTab(0)">
-				Artistarkiv
+				Artister
 			</a>
 		</li>
 
 		<li class="nav-item">
 			<a class="nav-link @(selectedTab== 1 ? "active-tab" : "" )" @onclick="() => SelectTab(1)">
-				Låtarkiv
+				Låter
 			</a>
 		</li>
 	</ul>

--- a/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
+++ b/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
@@ -250,7 +250,7 @@
 		var result = await ArtistService.GetAllArtistsAsync();
 		if (result.IsSuccess)
 		{
-			allArtists = result.Value.ToList();
+			allArtists = result.Value.OrderBy(a => a.Name).ToList();
 			artistsLoaded = true;
 		}
 	}

--- a/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
+++ b/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
@@ -29,9 +29,7 @@
 						<select name="sjanger" id="sjanger" class="form-control" @bind="editable.Genre">
 							<option value="" style="color: gray;">Velg en sjanger</option>
 							<option value="Hands Up">Hands Up</option>
-							<option value="Hard Trance">Hard Trance</option>
 							<option value="Hardstyle">Hardstyle</option>
-							<option value="Jumpstyle">Jumpstyle</option>
 							<option value="House">House</option>
 							<option value="Trance">Trance</option>
 							<option value="Happy Hardcore">Happy Hardcore</option>
@@ -83,7 +81,6 @@
 
 									{
 										ToastService.ShowToast("ADVARSEL: Mer enn 5 artister per låt er ikke tillatt.", ToastType.Warning);
-
 									}
 								</div>
 							}

--- a/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
+++ b/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
@@ -1,101 +1,49 @@
 ﻿@page "/Modal5"
-
 @using RMD.Data.Models
-
 @using RMD.Data.Models.DTO
-
 @using RMD.Business.Services
-
 @using RMD.GUI.Pages.Components.Toasts
 
-
-
 @inject ToastService ToastService
-
 @inject IArtistService ArtistService
 
-
-
 <div class="modal-backdrop">
-
 	<div class="container_parent">
-
 		<div class="main_form_container">
-
-
-
 			<i class="bi bi-pencil-square"></i>
-
-
-
 			<h3>Rediger låt</h3>
-
-
-
 			<div id="a_b_container">
-
 				<div id="reg_song_part_a">
-
 					<div id="form-group">
-
 						<label>Tittel</label>
-
 						<input type="text" class="form-control" @bind="editable.Title" />
-
 					</div>
 
-
-
 					<div id="form-group">
-
 						<label>Lengde (MM:SS)</label>
-
 						<input type="text" class="form-control" @bind="editable.Length" />
-
 					</div>
-
-
 
 					<div id="form-group">
-
 						<label>Sjanger</label>
-
 						<select name="sjanger" id="sjanger" class="form-control" @bind="editable.Genre">
-
+							<option value="" style="color: gray;">Velg en sjanger</option>
 							<option value="Hands Up">Hands Up</option>
-
 							<option value="Hard Trance">Hard Trance</option>
-
 							<option value="Hardstyle">Hardstyle</option>
-
 							<option value="Jumpstyle">Jumpstyle</option>
-
+							<option value="House">House</option>
 							<option value="Trance">Trance</option>
-
 							<option value="Happy Hardcore">Happy Hardcore</option>
-
-							<option value="UK Hardcore">UK Hardcore</option>
-
 						</select>
-
 					</div>
-
-
 
 					<div class="artist_rows_windows">
-
 						<div id="form-group" style="margin-bottom:15px;">
-
 							<label>Artister</label>
 
-
-
-							@foreach (var row in artistRows)
-
-							{
-
+							@foreach (var row in artistRows){
 								<div class="artist_selection_container" @key="row.Key">
-
 									@if (artistsLoaded)
 									{
 										<InputSelect @bind-Value="row.SelectedId" TValue="int?" class="form-control">
@@ -113,350 +61,175 @@
 										</select>
 									}
 
-
-
-									@if (artistRows.Count > 1)
-
-									{
+									@if (artistRows.Count > 1){
 
 										<button type="button"
 												class="btn btn-sm btn-danger ms-2"
 												@onclick="() => RemoveArtistRow(row.Key)">
-
 											-
-
 										</button>
-
 									}
 
-
-
 									@if (artistRows.Count <= 5)
-
 									{
-
 										<button type="button"
 												class="btn btn-sm btn-light ms-2"
 												@onclick="AddArtistRow">
-
 											+
-
 										</button>
-
 									}
-
-
 
 									@if (artistRows.Count >= 5)
 
 									{
-
 										ToastService.ShowToast("ADVARSEL: Mer enn 5 artister per låt er ikke tillatt.", ToastType.Warning);
 
 									}
-
 								</div>
-
 							}
-
 						</div>
-
 					</div>
 
-
-
-					@if (remixIsToggled == true)
-
-					{
-
+					@if (remixIsToggled == true){
 						<div class="artist_rows_windows" style="margin-top: 1rem;">
-
 							<div id="form-group">
-
 								<label>Remix artister</label>
-
-
-
-								@foreach (var row in remixRows)
-
-								{
-
+									@foreach (var row in remixRows){
 									<div class="artist_selection_container" @key="row.Key">
-
 										<InputSelect @bind-Value="row.SelectedId" TValue="int?" class="form-control" style="width:18rem;">
-
 											<option value="">Velg remixartist</option>
-
 											@foreach (var a in allArtists)
-
 											{
-
 												<option value="@a.ArtistId">@a.Name</option>
-
 											}
-
 										</InputSelect>
-
-
 
 										@if (remixRows.Count > 1)
 
 										{
-
 											<button type="button"
 													class="btn btn-sm btn-danger ms-2"
 													@onclick="() => RemoveRemixRow(row.Key)">
-
 												-
-
 											</button>
-
 										}
-
-
 
 										@if (remixRows.Count <= 5)
 
 										{
-
 											<button type="button"
 													class="btn btn-sm btn-light ms-2"
 													@onclick="AddRemixRow">
-
 												+
-
 											</button>
-
 										}
 
-
-
 										@if (artistRows.Count >= 5)
-
 										{
 
 											ToastService.ShowToast("ADVARSEL: Mer enn 5 artister per låt er ikke tillatt.", ToastType.Warning);
-
 										}
-
 									</div>
-
 								}
-
 							</div>
-
 						</div>
 
 					}
-
-
-
-
-
 				</div>
-
-
 
 				<div id="reg_song_part_b">
-
-
-
 					<div class="form-check form-switch">
-
 						<input class="form-check-input" type="checkbox" id="extendedMixSwitch" @bind="remixIsToggled">
-
 						<label class="form-check-label" for="flexSwitchCheckDefault">Remix</label>
-
 						<label class="col-form-label-sm">Aktiver artistvalg for remixartist.</label>
-
 					</div>
 
-
-
 					<div class="form-check form-switch">
-
 						<input class="form-check-input" type="checkbox" id="extendedMixCheckbox" @bind="editable.ExtendedMix">
-
 						<label class="form-check-label" for="flexSwitchCheckDefault">Extended Mix</label>
-
 						<label class="col-form-label-sm">Mix med intro og outro.</label>
-
 					</div>
 
-
-
 					<div class="form-check form-switch">
-
 						<input class="form-check-input" type="checkbox" id="favoriteCheckbox" @bind="editable.Favorite" />
-
 						<label class="form-check-label" for="flexSwitchCheckDefault">Favoritt</label>
-
 						<label class="col-form-label-sm">Låten har favorittstatus.</label>
-
 					</div>
 
-
-
 					<div class="form-check form-switch">
-
 						<input class="form-check-input" type="checkbox" id="playedCheckbox" @bind="editable.Played">
-
 						<label class="form-check-label" for="flexSwitchCheckDefault">Spilt</label>
-
 						<label class="col-form-label-sm">Låten er spilt i en tidligere mixtape.</label>
-
 					</div>
 
-
-
 					<div class="form-check form-switch">
-
 						<input class="form-check-input" type="checkbox" id="storedCheckbox" @bind="editable.Stored">
-
 						<label class="form-check-label" for="flexSwitchCheckDefault">Lagret</label>
-
 						<label class="col-form-label-sm">Låten er lagret i samlingen.</label>
-
 					</div>
-
-
 
 					<div class="form-check form-switch">
-
 						<input class="form-check-input" type="checkbox" id="wantedCheckbox" @bind="editable.Wanted">
-
 						<label class="form-check-label" for="flexSwitchCheckDefault">Ønsket</label>
-
 						<label class="col-form-label-sm">Låten er ønsket og må skaffes.</label>
-
 					</div>
 
-
-
-					@if (editable.Played)
-
-					{
-
+					@if (editable.Played){
 						<div class="toggledInput">
-
 							<div id="form-group">
-
 								<label>Mixtape vol.</label>
-
 								<input type="number" class="form-control number_ticker" @bind="editable.PlayedInEp" />
-
 								<label class="col-form-label-sm">Låten er spilt i ep</label>
-
 							</div>
-
 						</div>
-
 					}
 
-
-
-					@if (editable.Wanted)
-
-					{
-
+					@if (editable.Wanted){
 						<div class="toggledInput">
-
 							<div id="form-group">
-
 								<label>Låtkilde</label>
-
 								<input type="text" class="form-control number_ticker" @bind="editable.WantedSongUrl" />
-
 								<label class="col-form-label-sm">URL til låten</label>
-
 							</div>
-
 						</div>
-
 					}
-
-
-
 				</div>
-
 			</div>
-
-
 
 			<div class="button_container">
-
-
-
 				<div class="cancel_button">
-
 					<button type="button" class="btn btn-secondary" @onclick="CloseEditModal">
-
 						Avbryt
-
 					</button>
-
 				</div>
-
-
 
 				<div class="save_button">
-
 					<button type="button" class="btn btn-success" @onclick="SaveChangesAsync">
-
 						Lagre endringer
-
 					</button>
-
 				</div>
-
 			</div>
-
 		</div>
-
 	</div>
-
 </div>
-
-
-
-
-
-
-
-
-
-
 
 @code {
 
 	private List<Artist> allArtists = new();
-
 	private bool remixIsToggled = false;
-
 	private bool hasInitialized = false;
 	private int currentSongId;
 	private bool artistsLoaded = false;
 
 	[Parameter] public bool IsVisible { get; set; }
-
 	[Parameter] public EventCallback<bool> OnClose { get; set; }
-
 	[Parameter] public EventCallback<SongUpdateDto> OnSave { get; set; }
-
 	[Parameter] public Song? Song { get; set; }
 
-
-
 	private class IdRow
-
 	{
-
 		public Guid Key { get; } = Guid.NewGuid();
-
 		public int? SelectedId { get; set; }
-
-
-
 		public IdRow(int? selectedId = null)
 
 		{
@@ -464,37 +237,17 @@
 			SelectedId = selectedId;
 
 		}
-
 	}
 
-
-
-	//Row model for UI binding
-
-	// private class IdRow { public Guid Key { get; } = Guid.NewGuid(); public int? SelectedId { get; set; } }
-
-
-
 	private List<IdRow> artistRows = new() { new IdRow() };
-
 	private List<IdRow> remixRows = new() { new IdRow() };
-
-
-
 	private SongUpdateDto editable = new();
 
-
-
 	void AddArtistRow() { if (artistRows.Count < 5) artistRows.Add(new IdRow()); }
-
 	void RemoveArtistRow(Guid key) { if (artistRows.Count > 1) artistRows.RemoveAll(r => r.Key == key); }
-
 	void AddRemixRow() { if (remixRows.Count < 5) remixRows.Add(new IdRow()); }
-
 	void RemoveRemixRow(Guid key) { if (remixRows.Count > 1) remixRows.RemoveAll(r => r.Key == key); }
-
-
-
+	
 	protected override async Task OnInitializedAsync()
 	{
 		var result = await ArtistService.GetAllArtistsAsync();
@@ -505,48 +258,25 @@
 		}
 	}
 	
-
-
-
 	private async Task SaveChangesAsync()
 
 	{
 
 		// collect from rows -> dto lists
-
 		editable.ArtistIds = artistRows.Where(r => r.SelectedId.HasValue).Select(r => r.SelectedId!.Value).Distinct().ToList();
-
 		editable.RemixArtistIds = remixRows.Where(r => r.SelectedId.HasValue).Select(r => r.SelectedId!.Value).Distinct().ToList();
 
-
-
 		await OnSave.InvokeAsync(editable);
-
-
-
 		var title = editable.Title.Length > 20 ? editable.Title[..20] + "..." : editable.Title;
 
 		ToastService.ShowToast($"SUKSESS! {title} ble endret.", ToastType.Success);
 
 		CloseEditModal();
-
 	}
 
-
-
-	private void CloseEditModal()
-
-	{
-
+	private void CloseEditModal(){
 		OnClose.InvokeAsync(false);
-
-
-
 	}
-
-
-
-
 
 	protected override async Task OnParametersSetAsync()
 	{

--- a/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
+++ b/RMD.GUI/Pages/Components/Modals/EditSongModal.razor
@@ -7,123 +7,85 @@
 @inject ToastService ToastService
 @inject IArtistService ArtistService
 
-<div class="modal-backdrop">
-	<div class="container_parent">
-		<div class="main_form_container">
-			<i class="bi bi-pencil-square"></i>
-			<h3>Rediger låt</h3>
-			<div id="a_b_container">
-				<div id="reg_song_part_a">
-					<div id="form-group">
-						<label>Tittel</label>
-						<input type="text" class="form-control" @bind="editable.Title" />
-					</div>
-
-					<div id="form-group">
-						<label>Lengde (MM:SS)</label>
-						<input type="text" class="form-control" @bind="editable.Length" />
-					</div>
-
-					<div id="form-group">
-						<label>Sjanger</label>
-						<select name="sjanger" id="sjanger" class="form-control" @bind="editable.Genre">
-							<option value="" style="color: gray;">Velg en sjanger</option>
-							<option value="Hands Up">Hands Up</option>
-							<option value="Hardstyle">Hardstyle</option>
-							<option value="House">House</option>
-							<option value="Trance">Trance</option>
-							<option value="Happy Hardcore">Happy Hardcore</option>
-						</select>
-					</div>
-
-					<div class="artist_rows_windows">
-						<div id="form-group" style="margin-bottom:15px;">
-							<label>Artister</label>
-
-							@foreach (var row in artistRows){
-								<div class="artist_selection_container" @key="row.Key">
-									@if (artistsLoaded)
-									{
-										<InputSelect @bind-Value="row.SelectedId" TValue="int?" class="form-control">
-											<option value="">Velg en artist</option>
-											@foreach (var a in allArtists)
-											{
-												<option value="@a.ArtistId">@a.Name</option>
-											}
-										</InputSelect>
-									}
-									else
-									{
-										<select class="form-control" disabled>
-											<option>Laster artister...</option>
-										</select>
-									}
-
-									@if (artistRows.Count > 1){
-
-										<button type="button"
-												class="btn btn-sm btn-danger ms-2"
-												@onclick="() => RemoveArtistRow(row.Key)">
-											-
-										</button>
-									}
-
-									@if (artistRows.Count <= 5)
-									{
-										<button type="button"
-												class="btn btn-sm btn-light ms-2"
-												@onclick="AddArtistRow">
-											+
-										</button>
-									}
-
-									@if (artistRows.Count >= 5)
-
-									{
-										ToastService.ShowToast("ADVARSEL: Mer enn 5 artister per låt er ikke tillatt.", ToastType.Warning);
-									}
-								</div>
-							}
+<EditForm Model="editable" OnValidSubmit="SaveChangesAsync">
+	<div class="modal-backdrop">
+		<div class="container_parent">
+			<div class="main_form_container">
+				<i class="bi bi-pencil-square"></i>
+				<h3>Rediger låt</h3>
+				<div id="a_b_container">
+					<div id="reg_song_part_a">
+						<div id="form-group">
+							<label>Tittel</label>
+							<input type="text" class="form-control" @bind="editable.Title" />
 						</div>
-					</div>
 
-					@if (remixIsToggled == true){
-						<div class="artist_rows_windows" style="margin-top: 1rem;">
-							<div id="form-group">
-								<label>Remix artister</label>
-									@foreach (var row in remixRows){
+						<div id="form-group">
+							<label>Lengde (MM:SS)</label>
+							<InputText class="form-control"
+									   @bind-Value="editable.Length" />
+
+							<ValidationMessage For="@(() => editable.Length)" />
+						</div>
+
+						<div id="form-group">
+							<label>Sjanger</label>
+							<select name="sjanger" id="sjanger" class="form-control" @bind="editable.Genre">
+								<option value="" style="color: gray;">Velg en sjanger</option>
+								<option value="Hands Up">Hands Up</option>
+								<option value="Hardstyle">Hardstyle</option>
+								<option value="House">House</option>
+								<option value="Trance">Trance</option>
+								<option value="Happy Hardcore">Happy Hardcore</option>
+							</select>
+						</div>
+
+						<div class="artist_rows_windows">
+							<div id="form-group" style="margin-bottom:15px;">
+								<label>Artister</label>
+
+								@foreach (var row in artistRows)
+								{
 									<div class="artist_selection_container" @key="row.Key">
-										<InputSelect @bind-Value="row.SelectedId" TValue="int?" class="form-control" style="width:18rem;">
-											<option value="">Velg remixartist</option>
-											@foreach (var a in allArtists)
-											{
-												<option value="@a.ArtistId">@a.Name</option>
-											}
-										</InputSelect>
-
-										@if (remixRows.Count > 1)
-
+										@if (artistsLoaded)
 										{
+											<InputSelect @bind-Value="row.SelectedId" TValue="int?" class="form-control">
+												<option value="">Velg en artist</option>
+												@foreach (var a in allArtists)
+												{
+													<option value="@a.ArtistId">@a.Name</option>
+												}
+											</InputSelect>
+										}
+										else
+										{
+											<select class="form-control" disabled>
+												<option>Laster artister...</option>
+											</select>
+										}
+
+										@if (artistRows.Count > 1)
+										{
+
 											<button type="button"
 													class="btn btn-sm btn-danger ms-2"
-													@onclick="() => RemoveRemixRow(row.Key)">
+													@onclick="() => RemoveArtistRow(row.Key)">
 												-
 											</button>
 										}
 
-										@if (remixRows.Count <= 5)
-
+										@if (artistRows.Count <= 5)
 										{
 											<button type="button"
 													class="btn btn-sm btn-light ms-2"
-													@onclick="AddRemixRow">
+													@onclick="AddArtistRow">
 												+
 											</button>
 										}
 
 										@if (artistRows.Count >= 5)
-										{
 
+										{
 											ToastService.ShowToast("ADVARSEL: Mer enn 5 artister per låt er ikke tillatt.", ToastType.Warning);
 										}
 									</div>
@@ -131,84 +93,137 @@
 							</div>
 						</div>
 
-					}
-				</div>
+						@if (remixIsToggled == true)
+						{
+							<div class="artist_rows_windows" style="margin-top: 1rem;">
+								<div id="form-group">
+									<label>Remix artister</label>
+									@foreach (var row in remixRows)
+									{
+										<div class="artist_selection_container" @key="row.Key">
+											<InputSelect @bind-Value="row.SelectedId" TValue="int?" class="form-control" style="width:18rem;">
+												<option value="">Velg remixartist</option>
+												@foreach (var a in allArtists)
+												{
+													<option value="@a.ArtistId">@a.Name</option>
+												}
+											</InputSelect>
 
-				<div id="reg_song_part_b">
-					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="extendedMixSwitch" @bind="remixIsToggled">
-						<label class="form-check-label" for="flexSwitchCheckDefault">Remix</label>
-						<label class="col-form-label-sm">Aktiver artistvalg for remixartist.</label>
-					</div>
+											@if (remixRows.Count > 1)
 
-					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="extendedMixCheckbox" @bind="editable.ExtendedMix">
-						<label class="form-check-label" for="flexSwitchCheckDefault">Extended Mix</label>
-						<label class="col-form-label-sm">Mix med intro og outro.</label>
-					</div>
+											{
+												<button type="button"
+														class="btn btn-sm btn-danger ms-2"
+														@onclick="() => RemoveRemixRow(row.Key)">
+													-
+												</button>
+											}
 
-					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="favoriteCheckbox" @bind="editable.Favorite" />
-						<label class="form-check-label" for="flexSwitchCheckDefault">Favoritt</label>
-						<label class="col-form-label-sm">Låten har favorittstatus.</label>
-					</div>
+											@if (remixRows.Count <= 5)
 
-					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="playedCheckbox" @bind="editable.Played">
-						<label class="form-check-label" for="flexSwitchCheckDefault">Spilt</label>
-						<label class="col-form-label-sm">Låten er spilt i en tidligere mixtape.</label>
-					</div>
+											{
+												<button type="button"
+														class="btn btn-sm btn-light ms-2"
+														@onclick="AddRemixRow">
+													+
+												</button>
+											}
 
-					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="storedCheckbox" @bind="editable.Stored">
-						<label class="form-check-label" for="flexSwitchCheckDefault">Lagret</label>
-						<label class="col-form-label-sm">Låten er lagret i samlingen.</label>
-					</div>
+											@if (artistRows.Count >= 5)
+											{
 
-					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="wantedCheckbox" @bind="editable.Wanted">
-						<label class="form-check-label" for="flexSwitchCheckDefault">Ønsket</label>
-						<label class="col-form-label-sm">Låten er ønsket og må skaffes.</label>
-					</div>
-
-					@if (editable.Played){
-						<div class="toggledInput">
-							<div id="form-group">
-								<label>Mixtape vol.</label>
-								<input type="number" class="form-control number_ticker" @bind="editable.PlayedInEp" />
-								<label class="col-form-label-sm">Låten er spilt i ep</label>
+												ToastService.ShowToast("ADVARSEL: Mer enn 5 artister per låt er ikke tillatt.", ToastType.Warning);
+											}
+										</div>
+									}
+								</div>
 							</div>
-						</div>
-					}
 
-					@if (editable.Wanted){
-						<div class="toggledInput">
-							<div id="form-group">
-								<label>Låtkilde</label>
-								<input type="text" class="form-control number_ticker" @bind="editable.WantedSongUrl" />
-								<label class="col-form-label-sm">URL til låten</label>
+						}
+					</div>
+
+					<div id="reg_song_part_b">
+						<div class="form-check form-switch">
+							<input class="form-check-input" type="checkbox" id="extendedMixSwitch" @bind="remixIsToggled">
+							<label class="form-check-label" for="flexSwitchCheckDefault">Remix</label>
+							<label class="col-form-label-sm">Aktiver artistvalg for remixartist.</label>
+						</div>
+
+						<div class="form-check form-switch">
+							<input class="form-check-input" type="checkbox" id="extendedMixCheckbox" @bind="editable.ExtendedMix">
+							<label class="form-check-label" for="flexSwitchCheckDefault">Extended Mix</label>
+							<label class="col-form-label-sm">Mix med intro og outro.</label>
+						</div>
+
+						<div class="form-check form-switch">
+							<input class="form-check-input" type="checkbox" id="favoriteCheckbox" @bind="editable.Favorite" />
+							<label class="form-check-label" for="flexSwitchCheckDefault">Favoritt</label>
+							<label class="col-form-label-sm">Låten har favorittstatus.</label>
+						</div>
+
+						<div class="form-check form-switch">
+							<input class="form-check-input" type="checkbox" id="playedCheckbox" @bind="editable.Played">
+							<label class="form-check-label" for="flexSwitchCheckDefault">Spilt</label>
+							<label class="col-form-label-sm">Låten er spilt i en tidligere mixtape.</label>
+						</div>
+
+						<div class="form-check form-switch">
+							<input class="form-check-input" type="checkbox" id="storedCheckbox" @bind="editable.Stored">
+							<label class="form-check-label" for="flexSwitchCheckDefault">Lagret</label>
+							<label class="col-form-label-sm">Låten er lagret i samlingen.</label>
+						</div>
+
+						<div class="form-check form-switch">
+							<input class="form-check-input" type="checkbox" id="wantedCheckbox" @bind="editable.Wanted">
+							<label class="form-check-label" for="flexSwitchCheckDefault">Ønsket</label>
+							<label class="col-form-label-sm">Låten er ønsket og må skaffes.</label>
+						</div>
+
+						@if (editable.Played)
+						{
+							<div class="toggledInput">
+								<div id="form-group">
+									<label>Mixtape vol.</label>
+									<input type="number" class="form-control number_ticker" @bind="editable.PlayedInEp" />
+									<label class="col-form-label-sm">Låten er spilt i ep</label>
+								</div>
 							</div>
-						</div>
-					}
-				</div>
-			</div>
+						}
 
-			<div class="button_container">
-				<div class="cancel_button">
-					<button type="button" class="btn btn-secondary" @onclick="CloseEditModal">
-						Avbryt
-					</button>
+						@if (editable.Wanted)
+						{
+							<div class="toggledInput">
+								<div id="form-group">
+									<label>Låtkilde</label>
+									<input type="text" class="form-control number_ticker" @bind="editable.WantedSongUrl" />
+									<label class="col-form-label-sm">URL til låten</label>
+								</div>
+							</div>
+						}
+					</div>
 				</div>
 
-				<div class="save_button">
-					<button type="button" class="btn btn-success" @onclick="SaveChangesAsync">
-						Lagre endringer
-					</button>
+				<div class="button_container">
+					<div class="cancel_button">
+						<button type="button" class="btn btn-secondary" @onclick="CloseEditModal">
+							Avbryt
+						</button>
+					</div>
+
+					<div class="save_button">
+						<button type="submit" class="btn btn-success">
+							Lagre endringer
+						</button>
+					</div>
 				</div>
 			</div>
 		</div>
 	</div>
-</div>
+	<DataAnnotationsValidator />
+	</EditForm>
+   
+
+
 
 @code {
 

--- a/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor
+++ b/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor
@@ -24,8 +24,14 @@
         <div class="toast_contents @toastCss">
             <i class="@iconCss"></i>
 
-            <div class="text_container">
+            @* <div class="text_container">
                 <p class="text-truncate" style="max-width: 350px; height: 100%;">@message</p>
+            </div> *@
+
+            <div class="text_container">
+                <p>
+                    <span style="max-width: 900px;" class="message-truncate">@message</span>
+                </p>
             </div>
 
             <i class="bi bi-x" @onclick="CloseToast"></i>
@@ -46,8 +52,6 @@
 
     private async void ShowToast(string msg, ToastType type)
     {
-
-
         message = msg;
 
         (toastCss, iconCss) = type switch

--- a/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor
+++ b/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor
@@ -46,7 +46,7 @@
 
     private async void ShowToast(string msg, ToastType type)
     {
-        
+
 
         message = msg;
 
@@ -70,6 +70,7 @@
     private void CloseToast()
     {
         visible = false;
+        StateHasChanged();
     }
 
     public void Dispose()

--- a/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor.css
+++ b/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor.css
@@ -1,9 +1,9 @@
 .rmd-toast-container {
     position: fixed;
-    bottom: 15px;
+    bottom: 5px;
+    margin-bottom: -0.5rem;
     right: 15px;
     align-items: flex-end;
-
     display: flex;
     flex-direction: column;
     z-index: 1051;
@@ -34,10 +34,21 @@ p {
     margin-top: 7px;
 }
 
-.text_container {
+.text_container p {
+    margin-top: 10px;
     display: flex;
     flex-direction: row;
     gap: 10px;
+    align-items: center;
+}
+
+.message-truncate {
+    display: inline-block;
+    max-width: 300px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
 }
 
 /*info*/

--- a/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor.css
+++ b/RMD.GUI/Pages/Components/Toasts/ToastComponent.razor.css
@@ -3,7 +3,7 @@
     bottom: 15px;
     right: 15px;
     align-items: flex-end;
-    pointer-events: none;
+
     display: flex;
     flex-direction: column;
     z-index: 1051;

--- a/RMD.GUI/Pages/Index.razor
+++ b/RMD.GUI/Pages/Index.razor
@@ -159,7 +159,6 @@
 		<div class="resources_container">
 			<h2 style="margin-left:3rem;">Ressurser</h2>
 
-
 			<div class="icon_heading">
 				<i class="bi bi-info-circle-fill" style="color: #feb019;"></i>
 				<h5> Informasjon</h5>
@@ -172,13 +171,10 @@
 				<a href="https://www.lololyrics.com">🔗 Lololyrics.com</a>
 			</div>
 
-
 			<div class="icon_heading">
 				<i class="bi bi-cart4" style="color: #ff4560;"></i>
 				<h5> Nettbutikker</h5>
 			</div>
-
-			
 
 			<div class="resource_item">
 				<a href="https://www.beatport.com">🔗 Beatport.com</a>
@@ -193,7 +189,6 @@
 				<a href="https://www.trackitdown.com">🔗 Trackitdown.com</a>
 			</div>
 
-			@* <h5>💾 Nedlasting</h5> *@
 			<div class="icon_heading">
 				<i class="bi bi-download" style="color: #00e396;"></i>
 				<h5> Nedlasting</h5>

--- a/RMD.GUI/Pages/Index.razor
+++ b/RMD.GUI/Pages/Index.razor
@@ -158,7 +158,13 @@
 
 		<div class="resources_container">
 			<h2 style="margin-left:3rem;">Ressurser</h2>
-			<h5>ℹ️ Informasjon</h5>
+
+
+			<div class="icon_heading">
+				<i class="bi bi-info-circle-fill" style="color: #feb019;"></i>
+				<h5> Informasjon</h5>
+			</div>
+			
 			<div class="resource_item">
 				<a href="https://www.discogs.com">🔗 Discogs.com</a>
 			</div>
@@ -167,7 +173,13 @@
 			</div>
 
 
-			<h5>🛒Nettbutikker</h5>
+			<div class="icon_heading">
+				<i class="bi bi-cart4" style="color: #ff4560;"></i>
+				<h5> Nettbutikker</h5>
+			</div>
+
+			
+
 			<div class="resource_item">
 				<a href="https://www.beatport.com">🔗 Beatport.com</a>
 			</div>
@@ -181,7 +193,13 @@
 				<a href="https://www.trackitdown.com">🔗 Trackitdown.com</a>
 			</div>
 
-			<h5>💾 Nedlasting</h5>
+			@* <h5>💾 Nedlasting</h5> *@
+			<div class="icon_heading">
+				<i class="bi bi-download" style="color: #00e396;"></i>
+				<h5> Nedlasting</h5>
+			</div>
+
+			
 			<div class="resource_item">
 				<a href="https://bootlegs-load.de/">🔗 Bootlegs-load.de</a>
 			</div>

--- a/RMD.GUI/Pages/RegisterSong.razor
+++ b/RMD.GUI/Pages/RegisterSong.razor
@@ -282,7 +282,9 @@
 
         if (result.IsSuccess)
         {
-            allArtists = result.Value.ToList();
+            allArtists = result.Value
+                .OrderBy(a => a.Name)
+                .ToList();
         }
     }
 

--- a/RMD.GUI/Pages/RegisterSong.razor
+++ b/RMD.GUI/Pages/RegisterSong.razor
@@ -35,9 +35,7 @@
                         <InputSelect @bind-Value="newSongDto.Genre" class="form-control">
                             <option value="" style="color: gray;">Velg en sjanger</option>
                             <option value="Hands Up">Hands Up</option>
-                            <option value="Hard Trance">Hard Trance</option>
                             <option value="Hardstyle">Hardstyle</option>
-                            <option value="Jumpstyle">Jumpstyle</option>
                             <option value="House">House</option>
                             <option value="Trance">Trance</option>
                             <option value="Happy Hardcore">Happy Hardcore</option>

--- a/RMD.GUI/Pages/RegisterSong.razor
+++ b/RMD.GUI/Pages/RegisterSong.razor
@@ -16,7 +16,7 @@
 
 <div class="container_parent">
     <div class="main_form_container">        
-        <EditForm Model="newSongDto" OnValidSubmit="SaveSong">
+        <EditForm Model="newSongDto" OnValidSubmit="SaveSong" novalidate>
             <DataAnnotationsValidator/>
             <div id="a_b_container">
                 <div id="reg_song_part_a">
@@ -26,8 +26,15 @@
                     </div>
 
                     <div id="form-group">
-                        <label>Lengde (MM:SS)</label>
-                        <InputText @bind-Value="newSongDto.Length" class="form-control" />
+                        <label>Lengde</label>
+                        <InputText 
+                            @bind-Value="newSongDto.Length" 
+                            class="form-control" 
+                            placeholder="MM:SS"
+                            pattern="^[0-5]?\d:[0-5]\d$"
+                            inputmode="numeric"
+                            />
+
                     </div>
 
                     <div id="form-group">

--- a/RMD.GUI/Pages/RegisterSong.razor
+++ b/RMD.GUI/Pages/RegisterSong.razor
@@ -38,6 +38,7 @@
                             <option value="Hard Trance">Hard Trance</option>
                             <option value="Hardstyle">Hardstyle</option>
                             <option value="Jumpstyle">Jumpstyle</option>
+                            <option value="House">House</option>
                             <option value="Trance">Trance</option>
                             <option value="Happy Hardcore">Happy Hardcore</option>
                         </InputSelect>

--- a/RMD.GUI/Pages/RegisterSong.razor.css
+++ b/RMD.GUI/Pages/RegisterSong.razor.css
@@ -26,7 +26,6 @@
     overflow-y: auto;
     padding-right: 8px; /* keep content clear of scrollbar */
     scrollbar-gutter: stable both-edges; /* avoid layout shift when scrollbar appears */
-    
 }
 
 .artist_selection_container {
@@ -37,26 +36,26 @@
     margin-bottom: 1rem;
 }
 
-.btn,.add_button {
+.btn, .add_button {
     margin-top: 1px;
     height: 2.5rem;
 }
 
 h3 {
     font-weight: 400;
-    font-size:xx-large;
+    font-size: xx-large;
     justify-content: center;
     color: white;
 }
 
-label{
+label {
     color: white;
 }
 
 
 /**Indre skjema - beholder for del a og b**/
-#a_b_container{
-    display: flex; 
+#a_b_container {
+    display: flex;
     flex-direction: row;
     margin-left: 5rem;
     width: 40rem;
@@ -78,7 +77,7 @@ label{
 #reg_song_part_b {
     display: flex;
     flex-direction: column;
-    margin-top:1.5rem;
+    margin-top: 1.5rem;
     width: 15rem;
 }
 
@@ -99,7 +98,7 @@ label{
 }
 
 .save_button {
-    margin-left:5rem;
+    margin-left: 5rem;
     margin-top: 1.5rem;
     position: relative;
     display: inline-block;
@@ -107,8 +106,8 @@ label{
 }
 
     .save_button:hover {
-    transform: scale(1.1);
-    transform-origin: center;
+        transform: scale(1.1);
+        transform-origin: center;
     }
 
 #form-group {
@@ -118,13 +117,13 @@ label{
     margin-bottom: 1rem;
 }
 
-.col-form-label-sm{
+.col-form-label-sm {
     font-size: x-small;
     display: flex;
     flex-direction: column;
 }
 
-.toggledInput{
+.toggledInput {
     width: 12rem;
 }
 
@@ -143,14 +142,14 @@ label{
 
     .main_form_container {
         display: flex;
-        flex-direction:column; 
+        flex-direction: column;
         width: auto;
         padding: 0;
         margin: 0;
         height: auto;
     }
 
-    #a_b_container{
+    #a_b_container {
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -158,19 +157,17 @@ label{
         margin: 0;
     }
 
-    #reg_song_part_a{
+    #reg_song_part_a {
         display: flex;
         flex-direction: column;
         padding-left: 5rem;
         width: 60%;
         margin-left: 3rem;
-
     }
 
     #reg_song_part_b {
         display: flex;
         flex-direction: column;
-        
         padding-left: 4rem;
         margin-left: 4rem;
         width: 50%;

--- a/RMD.GUI/Pages/SongListPage.razor
+++ b/RMD.GUI/Pages/SongListPage.razor
@@ -103,9 +103,9 @@
 				<th>Artister</th>
 				<th>Remixer</th>
 				<th>Lengde</th>
-				<th>URL</th>
 				<th>Sjanger</th>
 				<th>EP</th>
+				<th>URL</th>
 				<th>Extended</th>
 				<th>Favoritt</th>
 				<th>Lagret</th>
@@ -128,7 +128,6 @@
 				// Table data inserted + tooltip data
 				<tr @onclick="() => SelectSong(song)" 
 					class="@(selectedSong?.SongId == song.SongId ? "selected-row" : "")">
-
 					<td>@song.SongId</td>
 					<td class="text-truncate" 
 						style="max-width: 350px" 
@@ -160,21 +159,21 @@
 							}
 					</td>
 					<td>@song.Length</td>
+					<td>@song.Genre</td>
+					<td>@song.PlayedInEp</td>
 					<td class="text-truncate">
 						@if (song.WantedSongUrl != null)
 						{
-							<a href="@song.WantedSongUrl" 
-								target="_blank" 
-								rel="noopener noreferrer" 
-								title="@song.WantedSongUrl" 
-								style="text-decoration: none;">
+							<a href="@song.WantedSongUrl"
+							   target="_blank"
+							   rel="noopener noreferrer"
+							   title="@song.WantedSongUrl"
+							   style="text-decoration: none;">
 								🔗
 							</a>
 
 						}
 					</td>
-					<td>@song.Genre</td>
-					<td>@song.PlayedInEp</td>
 					<td>@(song.ExtendedMix ? "✅" : "❌")</td>
 					<td>@(song.Favorite ? "⭐" : "❌")</td>
 					<td>@(song.Stored ? "✅" : "❌")</td>

--- a/RMD.GUI/Pages/SongListPage.razor.css
+++ b/RMD.GUI/Pages/SongListPage.razor.css
@@ -55,13 +55,13 @@
 }
 
 .table-container {
-	margin-top: 5rem;
+	margin-top: 4rem;
 	margin-bottom: 3rem;
 	height: auto;
 	max-width: 100%;
 	width: 100%;
 	overflow-y: auto;
-	max-height: 31.5rem;
+	max-height: 34.9rem;
 	border-radius: 20px;
 	cursor: pointer;
 }
@@ -133,7 +133,7 @@ th {
 	flex-direction: row;
 	height: 2rem;
 	width: 100%;
-	margin-top: 3rem;
+	margin-top: 2rem;
 }
 
 .checkboxes{
@@ -150,6 +150,7 @@ th {
 	width: 20rem;
 	justify-content: space-between;
 	margin-left: 65%;
+	margin-top:-0.8rem;
 }
 
 .edit_button, .delete_button {

--- a/RMD.GUI/Pages/index.razor.css
+++ b/RMD.GUI/Pages/index.razor.css
@@ -20,6 +20,20 @@
 
 }
 
+.icon_heading{
+    display: flex;
+    flex-direction: row;
+}
+
+i {
+    margin-left: 3rem;
+    font-size: large;
+    font-style: normal;
+    color: white;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+}
+
 p {
     font-size: medium;
     color: white;
@@ -223,12 +237,11 @@ h4 {
 }
 
 h5 {
-    margin-left: 3rem;
+    margin-left: 0.5rem;
     font-size: large;
     font-weight: 400;
     color: white;
-    margin-top: 2rem;
-    margin-bottom: 1rem;
+    margin-top: 2.2rem;
 }
 
 a{

--- a/RMD.GUI/Shared/NavMenu.razor
+++ b/RMD.GUI/Shared/NavMenu.razor
@@ -21,7 +21,7 @@
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="Register">
-                <span class="oi oi-plus" aria-hidden="true"></span> Registrer
+                <span class="oi oi-plus" aria-hidden="true"></span> Legg til
             </NavLink>
         </div>
 


### PR DESCRIPTION
- [x] Sorted artist drop down conents by alphabetical order 
- [x] Validating song length format (MM:SS)
- [x] Swapped out emojis on dashboard right column for Bootstrap Icons
- [x] Fixed close button on toast component, removed unnecessary toast pop ups
- [x] Fixed genre display on artist pages, broke because of new data model
- [x] Various tweaks: artist grid container extended vertically to three rows. Renamed navigation buttons in main nav and tabs. 
